### PR TITLE
Disable PEAR.Functions.ValidDefaultValue.NotAtEnd

### DIFF
--- a/Wizaplace/ruleset.xml
+++ b/Wizaplace/ruleset.xml
@@ -4,5 +4,6 @@
     <rule ref="../../../escapestudios/symfony2-coding-standard/Symfony2">
         <exclude name="Symfony2.Commenting" />
         <exclude name="Symfony2.NamingConventions.ValidClassName" />
+        <exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
     </rule>
 </ruleset>


### PR DESCRIPTION
Don't force arguments with default values to be at the end of the function's signature.

It was briefly discussed on our internal Slack, and at least 2 people thought it would be better to disable this rule.

It causes issues when extending abstract services in Symfony.