### PR TITLE
Exclude some new Symfony rules

### DIFF
--- a/Wizaplace/ruleset.xml
+++ b/Wizaplace/ruleset.xml
@@ -5,5 +5,7 @@
         <exclude name="Symfony.Commenting" />
         <exclude name="Symfony.NamingConventions.ValidClassName" />
         <exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
+        <exclude name="Symfony.Functions.Arguments" />
+        <exclude name="Symfony.Errors.ExceptionMessage" />
     </rule>
 </ruleset>


### PR DESCRIPTION
`Symfony.Functions.Arguments`:

```php
public function __construct(
        Author $author,
        string $message,
        string $postedAt,
        int $rating
    ) {
```

> Declare all the arguments on the same line as the method/function name, no matter how many arguments there are.

`Symfony.Errors.ExceptionMessage`:

```php
throw new \TypeError('\Wizaplace\SDK\Catalog\ProductAttribute::getValue must return null, a string, or an array. Got '.var_export($value, true));
```

> Exception and error message strings must be concatenated using sprintf